### PR TITLE
Make TS rules saner

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,11 @@ const frontend = {
   "overrides": [
     {
       "files": ['*.ts', '*.tsx'],
-      "extends": ['plugin:@typescript-eslint/recommended']
+      "extends": ['plugin:@typescript-eslint/recommended'],
+      "rules": {
+        "@typescript-eslint/explicit-module-boundary-types": ["error"],
+        "@typescript-eslint/explicit-function-return-type": "off",
+      }
     }
   ],
   "rules": {
@@ -127,8 +131,9 @@ const frontend = {
 
     "react/button-has-type": [ 2, { "button": true, "submit": true, "reset": true } ],
     "react/default-props-match-prop-types": [ 2, { "allowRequiredDefaults": true } ],
-    "react/destructuring-assignment": [ 1, "always" ],
+    "react/destructuring-assignment": 0,
     "react/forbid-prop-types": 0,
+    "react/prop-types": 0,
     "react/require-default-props": 0,
     "react/require-extension": 0,
     "react/self-closing-comp": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@luckbox/eslint-rules",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luckbox/eslint-rules",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Unified eslint rules between projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- stopped "react/destructuring-assignment"
- stopped "react/prop-types"
- stopped "@typescript-eslint/explicit-function-return-type"
- bumped "@typescript-eslint/explicit-module-boundary-types" to "error"
